### PR TITLE
IM 0 instruction PUSH PC

### DIFF
--- a/Z80.js
+++ b/Z80.js
@@ -321,6 +321,7 @@ let interrupt = function(non_maskable, data)
       {
          // In the 8080-compatible interrupt mode,
          //  decode the content of the data bus as an instruction and run it.
+         push_word(pc);
          decode_instruction(data);
          cycle_counter += 2;
       }


### PR DESCRIPTION
I think the `IM 0` instruction needs to push the PC before processing the byte that comes from the data bus (containing an `RST` instruction), otherwise there is no way the Z80 can resume after the interrupt has been served.

I wanted to push this PR on DrGoldfire repo's, but it has been now marked as read only.